### PR TITLE
Add public method to force scrollview appearance update

### DIFF
--- a/Pod/Classes/JPBParallaxBlurViewController.h
+++ b/Pod/Classes/JPBParallaxBlurViewController.h
@@ -17,6 +17,11 @@
 - (CGFloat)headerHeight;
 - (UIScrollView*)mainScrollView;
 
+/**
+ *  This should be called whenever the content size of the scrollview need to be adjusted.
+ */
+- (void)setNeedsScrollViewAppearanceUpdate;
+
 @property (weak, nonatomic, readwrite) id <JPBParallaxBlurInteractionsDelegate> interactionsDelegate;
 
 @end

--- a/Pod/Classes/JPBParallaxBlurViewController.m
+++ b/Pod/Classes/JPBParallaxBlurViewController.m
@@ -90,6 +90,11 @@ static CGFloat IMAGE_HEIGHT = 320.0f;
 
 - (void)viewDidAppear:(BOOL)animated{
     [super viewDidAppear:animated];
+    [self setNeedsScrollViewAppearanceUpdate];
+}
+
+- (void)setNeedsScrollViewAppearanceUpdate
+{
     _mainScrollView.contentSize = CGSizeMake(CGRectGetWidth(self.view.frame), _contentView.contentSize.height + CGRectGetHeight(_backgroundScrollView.frame));
 }
 


### PR DESCRIPTION
It fixes my issue when the tableview's content size changes after `viewDidAppear`, but I wonder if there's a better place to put it. Perhaps it wouldn't even need to be available as a public method.
